### PR TITLE
Tighten e2e geo test helpers per UI test guidance

### DIFF
--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -54,28 +54,12 @@ test.describe('Website', () => {
 
   test.describe('when geolocation fails then succeeds on retry', () => {
     test('recovers and shows NDB info after retry', async ({
-      geoFake,
+      geoFailThenSucceed,
       noLocationPage,
       ndbResultPage,
       page,
     }) => {
-      await geoFake(`
-        let callCount = 0;
-        navigator.geolocation.getCurrentPosition = (success, error) => {
-          callCount++;
-          if (callCount === 1) {
-            error({
-              code: 2,
-              message: 'Position unavailable',
-              PERMISSION_DENIED: 1,
-              POSITION_UNAVAILABLE: 2,
-              TIMEOUT: 3,
-            });
-          } else {
-            success({ coords: { latitude: 36.0, longitude: -121.0 } });
-          }
-        };
-      `)
+      await geoFailThenSucceed({ latitude: 36.0, longitude: -121.0 })
 
       await expect(page.getByText('Unable to get your location')).toBeVisible()
       await expect(noLocationPage.retryButton).toBeVisible()

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -7,7 +7,7 @@ type GeoFixtures = {
   noLocationPage: NoLocationPage
   geoSuccess: (latitude: number, longitude: number) => Promise<void>
   geoError: (code: number, message: string) => Promise<void>
-  geoFake: (script: string) => Promise<void>
+  geoFailThenSucceed: (coords: { latitude: number; longitude: number }) => Promise<void>
 }
 
 export const test = base.extend<GeoFixtures>({
@@ -50,9 +50,28 @@ export const test = base.extend<GeoFixtures>({
     })
   },
 
-  geoFake: async ({ page }, use) => {
-    await use(async (script: string) => {
-      await page.addInitScript(script)
+  geoFailThenSucceed: async ({ page }, use) => {
+    await use(async (coords: { latitude: number; longitude: number }) => {
+      await page.addInitScript((coords) => {
+        let callCount = 0
+        navigator.geolocation.getCurrentPosition = (
+          success: PositionCallback,
+          error?: PositionErrorCallback | null,
+        ) => {
+          callCount++
+          if (callCount === 1) {
+            error?.({
+              code: 2,
+              message: 'Position unavailable',
+              PERMISSION_DENIED: 1,
+              POSITION_UNAVAILABLE: 2,
+              TIMEOUT: 3,
+            } as GeolocationPositionError)
+          } else {
+            success({ coords } as GeolocationPosition)
+          }
+        }
+      }, coords)
       await page.goto('/')
     })
   },

--- a/e2e/pages/NdbResultPage.ts
+++ b/e2e/pages/NdbResultPage.ts
@@ -17,16 +17,4 @@ export class NdbResultPage extends BasePage {
   get name(): Locator {
     return this.page.getByTestId('ndb-name')
   }
-
-  get frequency(): Locator {
-    return this.page.getByTestId('ndb-freq')
-  }
-
-  get identifier(): Locator {
-    return this.page.getByTestId('ndb-id')
-  }
-
-  get coordinates(): Locator {
-    return this.page.getByTestId('ndb-coords')
-  }
 }


### PR DESCRIPTION
## Summary

Two minor e2e test-quality fixes from a verified audit, aligned with the Playwright UI test guidance (resilient locators via `getByTestId`, web-first assertions, fixtures own lifecycle / helpers own actions).

## Findings addressed

- **Finding 1 — dead code (`e2e/pages/NdbResultPage.ts`):** Removed the `frequency`, `identifier`, and `coordinates` getters. No spec referenced them, and `knip` confirms nothing else does. The `ndb-freq` / `ndb-id` / `ndb-coords` testids still exist in `InfoView.vue` and remain covered by the component unit tests, so no component change was needed.
- **Finding 2 — setup leak (`e2e/e2e.spec.ts`):** The "fail once, then succeed" retry test inlined a multi-line `getCurrentPosition` stub as a raw `addInitScript` string. Extracted it into a typed `geoFailThenSucceed(coords)` fixture in `e2e/fixtures.ts`, beside the existing `geoSuccess` / `geoError` helpers, so the fixture owns the geo lifecycle and the spec stays declarative. The now-unused generic `geoFake` fixture was replaced by it (it had no other callers; leaving it would be dead code that `knip` flags).

No deferrals.

## Verification

All run with pnpm (project's package manager):

- `pnpm type-check` (vue-tsc) — pass
- `pnpm lint` (eslint + oxlint + stylelint + knip) — pass (knip exit 0; remaining output is pre-existing `knip.json` config hints, unrelated)
- `pnpm test:unit` (vitest) — 19 passed, 2 skipped (pre-existing)
- `npx playwright test --list` — all 27 specs compile
- Full `npx playwright test` against the auto-started preview server — **27 passed** across chromium, firefox, and webkit, including the converted retry-recovery test

🤖 Generated with [Claude Code](https://claude.com/claude-code)