### PR TITLE
Tidy NDB result page object and extract geo retry helper

### DIFF
--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -54,28 +54,12 @@ test.describe('Website', () => {
 
   test.describe('when geolocation fails then succeeds on retry', () => {
     test('recovers and shows NDB info after retry', async ({
-      geoFake,
+      geoFailThenSucceed,
       noLocationPage,
       ndbResultPage,
       page,
     }) => {
-      await geoFake(`
-        let callCount = 0;
-        navigator.geolocation.getCurrentPosition = (success, error) => {
-          callCount++;
-          if (callCount === 1) {
-            error({
-              code: 2,
-              message: 'Position unavailable',
-              PERMISSION_DENIED: 1,
-              POSITION_UNAVAILABLE: 2,
-              TIMEOUT: 3,
-            });
-          } else {
-            success({ coords: { latitude: 36.0, longitude: -121.0 } });
-          }
-        };
-      `)
+      await geoFailThenSucceed({ latitude: 36.0, longitude: -121.0 })
 
       await expect(page.getByText('Unable to get your location')).toBeVisible()
       await expect(noLocationPage.retryButton).toBeVisible()

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -7,7 +7,7 @@ type GeoFixtures = {
   noLocationPage: NoLocationPage
   geoSuccess: (latitude: number, longitude: number) => Promise<void>
   geoError: (code: number, message: string) => Promise<void>
-  geoFake: (script: string) => Promise<void>
+  geoFailThenSucceed: (coords: { latitude: number; longitude: number }) => Promise<void>
 }
 
 export const test = base.extend<GeoFixtures>({
@@ -50,9 +50,28 @@ export const test = base.extend<GeoFixtures>({
     })
   },
 
-  geoFake: async ({ page }, use) => {
-    await use(async (script: string) => {
-      await page.addInitScript(script)
+  geoFailThenSucceed: async ({ page }, use) => {
+    await use(async (coords: { latitude: number; longitude: number }) => {
+      await page.addInitScript((coords) => {
+        let callCount = 0
+        navigator.geolocation.getCurrentPosition = (
+          success: PositionCallback,
+          error?: PositionErrorCallback | null,
+        ) => {
+          callCount++
+          if (callCount === 1) {
+            error?.({
+              code: 2,
+              message: 'Position unavailable',
+              PERMISSION_DENIED: 1,
+              POSITION_UNAVAILABLE: 2,
+              TIMEOUT: 3,
+            } as GeolocationPositionError)
+          } else {
+            success({ coords } as GeolocationPosition)
+          }
+        }
+      }, coords)
       await page.goto('/')
     })
   },

--- a/e2e/pages/NdbResultPage.ts
+++ b/e2e/pages/NdbResultPage.ts
@@ -17,16 +17,4 @@ export class NdbResultPage extends BasePage {
   get name(): Locator {
     return this.page.getByTestId('ndb-name')
   }
-
-  get frequency(): Locator {
-    return this.page.getByTestId('ndb-freq')
-  }
-
-  get identifier(): Locator {
-    return this.page.getByTestId('ndb-id')
-  }
-
-  get coordinates(): Locator {
-    return this.page.getByTestId('ndb-coords')
-  }
 }


### PR DESCRIPTION
Targeted e2e test cleanups toward the Playwright UI test guidance. The diff is intentionally tight.

## Findings addressed

- **Dead code in `e2e/pages/NdbResultPage.ts`** — removed the `frequency`, `identifier`, and `coordinates` getters. No spec referenced them (only `distance`, `name`, and the inherited `heading` are used).
- **Setup leak in `e2e/e2e.spec.ts`** — the "fails then succeeds on retry" test inlined a multi-line `getCurrentPosition` stub as a raw `addInitScript` string via the generic `geoFake` fixture. Extracted it into a purpose-built `geoFailThenSucceed(coords)` fixture in `e2e/fixtures.ts`, beside the existing `geoSuccess` / `geoError` helpers, mirroring `geoError`'s typed callback style. The retry spec is now declarative: `await geoFailThenSucceed({ latitude: 36.0, longitude: -121.0 })`. The now-unused `geoFake` fixture (its only caller) was removed with it.

No deferrals.

## Verification

All run with Node 26.3.0 (`.nvmrc`) via pnpm:

- `pnpm type-check` (vue-tsc): pass
- `pnpm lint` (eslint + oxlint + stylelint + knip): pass
- `pnpm test:unit --run` (vitest): 19 passed, 2 skipped
- `npx playwright test --list`: 27 tests compile across chromium/firefox/webkit
- `npx playwright test --project=chromium` (auto-started webServer): 9 passed, including the refactored retry test
- `prettier --check` on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)