### PR TITLE
Modern Swift concurrency

### DIFF
--- a/generate-navaids/Package.swift
+++ b/generate-navaids/Package.swift
@@ -3,6 +3,11 @@
 
 import PackageDescription
 
+let approachableConcurrency: [SwiftSetting] = [
+  .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+  .enableUpcomingFeature("InferIsolatedConformances")
+]
+
 let package = Package(
   name: "generate-navaids",
   platforms: [.macOS(.v13)],
@@ -15,11 +20,13 @@ let package = Package(
     // Targets can depend on other targets in this package, and on products in packages this package depends on.
     .executableTarget(
       name: "generate-navaids",
-      dependencies: ["SwiftNASR"]
+      dependencies: ["SwiftNASR"],
+      swiftSettings: approachableConcurrency
     ),
     .testTarget(
       name: "generate-navaidsTests",
-      dependencies: ["generate-navaids"]
+      dependencies: ["generate-navaids"],
+      swiftSettings: approachableConcurrency
     )
   ],
   swiftLanguageModes: [.v6]


### PR DESCRIPTION
## Summary

Adopts the Approachable Concurrency upcoming features for the
`generate-navaids` executable (a build tool that generates navaid data
from SwiftNASR). Both the executable and test targets now enable:

- `NonisolatedNonsendingByDefault`
- `InferIsolatedConformances`

These are applied via a shared `approachableConcurrency` `SwiftSetting`
list in `Package.swift`. This is a flags-only change; no source code
required migration.

## Verification

- `swift build --build-tests` succeeds (executable + test targets
  compile cleanly under the new upcoming-feature flags).
- The package's test target contains no unit tests; nothing to run.
- `generate-navaids` is a build tool (not one of the shipped libraries
  or E2E executables), so there is no public API surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
